### PR TITLE
Flesh out contact approval processes (SOFTWARE-5458)

### DIFF
--- a/docs/policy/comanage-instructions-admin.md
+++ b/docs/policy/comanage-instructions-admin.md
@@ -2,8 +2,8 @@ Approving COManage Registrations
 ================================
 
 OSG is using a new identity management system called COManage.
-Initially, this system will be used for managing access to OSG staff-internal monitoring webpages at UNL,
-and managing access for OASIS logins.
+This system is used for managing contact information for OSPool and PATh Facility users, Topology site contacts, and
+OSG/PATh staff.
 
 User registrations must be manually approved by a COManage admin.
 Follow the instructions below to approve a user registration.
@@ -13,46 +13,52 @@ Follow the instructions below to approve a user registration.
     If you are a user who wants to register with COManage,
     go to the [Registering for the OSG COManage](https://osg-htc.org/docs/common/contact-registration) page instead.
 
+1.  Check for contact registration requests:
 
-1.  Check for an email from <registry@cilogon.org> saying "Petition for <NAME> changed status from
-    Confirmed to Pending Approval".
+    -   If you are a COManage sponsor for a given group of registrants, you will receive email notifications when there
+        are new registration requests.
+        Check for an email from <registry@cilogon.org> saying "Petition for <NAME> changed status from
+        Confirmed to Pending Approval" and visit the first link in the body.
 
-1.  Click the first link in the email.
+    -   Alternatively, you can view all requests pending approval
+        [here](https://registry.cilogon.org/registry/co_petitions/index/co:7/sort:CoPetition.created/direction:desc/search.status:PA).
+        Click on the registrant's name to view their request.
 
-1.  Log in with your institutional credentials.
-    You should see a "View CO Petition..." page.
-    The Status should be "Pending Approval".
-    
-    !!! note
-    	You can also access this page by logging into https://registry.cilogon.org/registry and
-    	clicking on "CO Petitions" under the left-hand "People" menu. 
+1.  If prompted, log in with your institutional credentials.
 
-1.  Click on the name of the pending application. 
-	This will take to you the page where you can see their full application and 
-	have the option to approve them. 
+1.  Review the request:
 
-1.  Verify that the application is legitimate.
-    Ask someone affiliated with the site, VO, or the sponsor of a project to verify the applicant's affiliation.
-    In the future, applicants will be asked to provide the contact information of such a person --
-    similar to our existing [contact registration process](https://osg-htc.org/docs/common/registration/).
+    1.  Verify that the request is legitimate by doing at least one of the following:
+
+        -   Find associated support tickets by searching for their email address in Freshdesk
+        -   Ask someone affiliated with the site, VO, or the sponsor of a project to verify the registrant's
+            affiliation.
+        -   Ask if other staff have been in contact with them via the `#staff` Slack channel
+
+    1.  Verify that the registrant has submitted their request using the correct form,
+        e.g. OSPool users should not have submitted a request to register as a Topology contact.
+
+1.  In the top-right corner, click the "Add comment" link and add a note indicating how you verified the request
+
+    !!! danger "'Approver Comment' is public"
+        The registrant will see notes added to the "Approver Comment" field
 
 1.  Click the "Approve" button.
     You should see "Petition Approved" and "Petition Finalized" on top.
     The Status should now be "Finalized".
 
-1.  The user will get an email saying "Petition for <NAME> changed status from Pending Approval to
-    Approved".
+1.  Click on their name next to `CO Person` to verify that the registrant is `Active` and that they are in the expected
+    groups.
 
-    The links in the email are expected to be useless
-    (the first link will give them "Permission Denied" and
-    the second link will merely allow them to "acknowledge" that they received the email).
-
-    If the user asks, reassure them that they are registered and no further action needs to be taken.
+1.  The user will get an email saying "Petition for <NAME> changed status from Pending Approval to Approved".
 
 Troubleshooting
 ---------------
 
 ### The COManage petition is stuck in the "confirmed" state
+
+This may happen if there are issues when confirming the user's email address.
+We have seen this occur if a user clicks the confirmation link then closes the tab too quickly.
 
 1.  Under the `People` drop-down on the left,  click on `My Population`
 

--- a/docs/policy/comanage-instructions-admin.md
+++ b/docs/policy/comanage-instructions-admin.md
@@ -31,7 +31,7 @@ Follow the instructions below to approve a user registration.
     1.  Verify that the request is legitimate by doing at least one of the following:
 
         -   Find associated support tickets by searching for their email address in Freshdesk
-        -   Ask someone affiliated with the site, VO, or the sponsor of a project to verify the registrant's
+        -   Ask someone affiliated with the site, collaboration, or the sponsor of a project to verify the registrant's
             affiliation.
         -   Ask if other staff have been in contact with them via the `#staff` Slack channel
 


### PR DESCRIPTION
The big change here is spelling out how to validate a registration request and that we should track that in an internal comment of the request.

FYI @rachellombardi @ChristinaLK 